### PR TITLE
Add healthcheck configuration for RabbitMQ service in Docker Compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,8 @@ jobs:
 
       - name: Start services (Smoke Test)
         run: |
-          # Levantamos todo en detach mode
-          docker compose up -d
-          
-          # Esperamos unos segundos para ver si algún contenedor crashea inmediatamente
-          sleep 10
+          # Levantamos todo y esperamos a que los healthchecks pasen (hasta 120s)
+          docker compose up -d --wait --wait-timeout 120
           
       - name: Check container status
         run: |
@@ -59,11 +56,11 @@ jobs:
           docker compose ps
           
           # Si algún contenedor salió (Exited), fallamos el CI
-          EXITED=$(docker compose ps -q | xargs docker inspect -f '{{ .State.Status }}' | grep -v "running" || true)
-          if [ ! -z "$EXITED" ]; then
+          EXITED=$(docker compose ps -q | xargs docker inspect -f '{{ .State.Status }}' | grep -c -v "running" || true)
+          if [ "$EXITED" -gt "0" ]; then
             echo "❌ Fallo: Algunos contenedores no están corriendo."
             echo "=== Logs ==="
-            docker compose logs
+            docker compose logs --tail=50
             exit 1
           else
             echo "✅ Todo en orden, contenedores corriendo."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,11 @@ services:
     ports:
       - "5672:5672"
       - "15672:15672"
+    healthcheck:
+      test: ["CMD", "rabbitmqctl", "status"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   # --- Ticket DB ---
   db:
@@ -70,7 +75,7 @@ services:
       db:
         condition: service_healthy
       rabbitmq:
-        condition: service_started
+        condition: service_healthy
 
     ports:
       - "8000:8000"
@@ -102,7 +107,7 @@ services:
       users-db:
         condition: service_healthy
       rabbitmq:
-        condition: service_started
+        condition: service_healthy
     # OJO: users escucha 8001 adentro, pero lo exponemos como 8003 afuera para matchear frontend.
     ports:
       - "8003:8001"
@@ -132,7 +137,7 @@ services:
       users-db:
         condition: service_healthy
       rabbitmq:
-        condition: service_started
+        condition: service_healthy
       users-service:
         condition: service_started
     restart: on-failure
@@ -183,7 +188,7 @@ services:
       notification-db:
         condition: service_healthy
       rabbitmq:
-        condition: service_started
+        condition: service_healthy
     ports:
       - "8001:8001"
     restart: unless-stopped
@@ -214,7 +219,7 @@ services:
       notification-db:
         condition: service_healthy
       rabbitmq:
-        condition: service_started
+        condition: service_healthy
       notification-service:
         condition: service_started
     healthcheck:
@@ -269,7 +274,7 @@ services:
       assignment-db:
         condition: service_healthy
       rabbitmq:
-        condition: service_started
+        condition: service_healthy
     ports:
       - "8002:8001"
     restart: unless-stopped
@@ -298,7 +303,7 @@ services:
       assignment-db:
         condition: service_healthy
       rabbitmq:
-        condition: service_started
+        condition: service_healthy
       assignment-service:
         condition: service_started
     restart: on-failure
@@ -325,7 +330,7 @@ services:
       assignment-db:
         condition: service_healthy
       rabbitmq:
-        condition: service_started
+        condition: service_healthy
     restart: on-failure
 
   # --- Frontend ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -217,6 +217,11 @@ services:
         condition: service_started
       notification-service:
         condition: service_started
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import socket; s=socket.socket(); s.settimeout(5); s.connect(('rabbitmq', 5672)); s.close()\" || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
     restart: on-failure
 
   # --- Assignment DB ---


### PR DESCRIPTION
This pull request adds a health check to the `notification-service` in the `docker-compose.yml` file. The health check ensures that the service only starts if it can successfully connect to the `rabbitmq` service on port 5672.

Service reliability improvements:

* Added a `healthcheck` to `notification-service` that attempts to connect to `rabbitmq:5672` using Python, with specified interval, timeout, and retry settings.…-compose.yml